### PR TITLE
Improve inference of eltype in matrix multiplication

### DIFF
--- a/src/arraymath.jl
+++ b/src/arraymath.jl
@@ -115,18 +115,6 @@ end
 # @generated function Base.zeros!{SA <: StaticArray}(a::SA)
 # @generated function Base.ones!{SA <: StaticArray}(a::SA)
 
-@generated function Base.fill!{SA <: StaticArray}(a::SA, val)
-    l = length(SA)
-    T = eltype(SA)
-    exprs = [:(@inbounds a[$i] = valT) for i = 1:l]
-    return quote
-        $(Expr(:meta, :inline))
-        valT = convert($T, val)
-        $(Expr(:block, exprs...))
-        return a
-    end
-end
-
 @generated function Base.rand!{SA <: StaticArray}(rng::AbstractRNG, a::SA)
     l = length(SA)
     T = eltype(SA)

--- a/src/matrix_multiply.jl
+++ b/src/matrix_multiply.jl
@@ -94,7 +94,7 @@ end
     sb = size(b)
 
     s = (sA[1],)
-    T = promote_type(TA, Tb)
+    T = typeof(zero(TA)*zero(Tb))
 
     if sb[1] != sA[2]
         error("Dimension mismatch")
@@ -133,7 +133,7 @@ end
     sB = size(B)
 
     s = (sa[1],sB[2])
-    T = promote_type(Ta, TB)
+    T = typeof(zero(Ta)*zero(TB))
 
     if sB[1] != 1
         error("Dimension mismatch")
@@ -167,7 +167,7 @@ end
     TA = eltype(A)
     TB = eltype(B)
 
-    T = promote_type(TA, TB)
+    T = typeof(zero(TA)*zero(TB))
 
     can_mutate = !isbits(A) || !isbits(B) # !isbits implies can get a persistent pointer (to pass to BLAS). Probably will change to !isimmutable in a future version of Julia.
     can_blas = T == TA && T == TB && T <: Union{Float64, Float32, Complex{Float64}, Complex{Float32}}
@@ -229,7 +229,7 @@ end
     TB = eltype(B)
 
     s = (sA[1], sB[2])
-    T = promote_type(TA, TB)
+    T = typeof(zero(TA)*zero(TB))
 
     if sB[1] != sA[2]
         error("Dimension mismatch")
@@ -270,7 +270,7 @@ end
     TB = eltype(B)
 
     s = (sA[1], sB[2])
-    T = promote_type(TA, TB)
+    T = typeof(zero(TA)*zero(TB))
 
     if sB[1] != sA[2]
         error("Dimension mismatch")
@@ -315,7 +315,7 @@ end
     TB = eltype(B)
 
     s = (sA[1], sB[2])
-    T = promote_type(TA, TB)
+    T = typeof(zero(TA)*zero(TB))
 
     if sB[1] != sA[2]
         error("Dimension mismatch")
@@ -359,7 +359,7 @@ end
     sb = size(b)
 
     s = (sA[1],)
-    T = promote_type(TA, Tb)
+    T = typeof(zero(TA)*zero(Tb))
 
     if sb[1] != sA[2]
         error("Dimension mismatch")
@@ -417,7 +417,7 @@ end
 
     TA = eltype(A)
     TB = eltype(B)
-    T = promote_type(TA, TB)
+    T = typeof(zero(TA)*zero(TB))
 
     can_blas = T == TA && T == TB && T <: Union{Float64, Float32, Complex{Float64}, Complex{Float32}}
 

--- a/test/matrix_multiply.jl
+++ b/test/matrix_multiply.jl
@@ -3,6 +3,11 @@
         m = @SMatrix [1 2; 3 4]
         v = @SVector [1, 2]
         @test m*v === @SVector [5, 11]
+        # More complicated eltype inference
+        v = @SVector [CartesianIndex((1,3)), CartesianIndex((3,1))]
+        x = @inferred(m*v)
+        @test isa(x, SVector{2,CartesianIndex{2}})
+        @test x == @SVector [CartesianIndex((7,5)), CartesianIndex((15,13))]
 
         m = @MMatrix [1 2; 3 4]
         v = @MVector [1, 2]
@@ -26,7 +31,11 @@
     @testset "Matrix-matrix" begin
         m = @SMatrix [1 2; 3 4]
         n = @SMatrix [2 3; 4 5]
-        @test m*n === @SMatrix [10 13; 22 29]
+        nc = @SMatrix [CartesianIndex((2,2)) CartesianIndex((3,3));
+                       CartesianIndex((4,4)) CartesianIndex((5,5))]
+        @test m*n  === @SMatrix [10 13; 22 29]
+        @test m*nc === @SMatrix [CartesianIndex((10,10)) CartesianIndex((13,13));
+                                 CartesianIndex((22,22)) CartesianIndex((29,29))]
 
         @test m'*n === @SMatrix [14 18; 20 26]
         @test m*n' === @SMatrix [8 14; 18 32]


### PR DESCRIPTION
I was using this in image processing and multiplying a matrix of `Float32` times a vector of `RGB{Float32}`.

The only risk here is that `zero(T)` might fail. I'm not sure what else to do, though.
