### PR TITLE
Make Array-of-SArray `op` Number infer the right output Array type

### DIFF
--- a/src/arraymath.jl
+++ b/src/arraymath.jl
@@ -1,5 +1,10 @@
 import Base: .+, .-, .*, ./
 
+# Support for elementwise ops on AbstractArray{S<:StaticArray} with Number
+Base.promote_op{Op,A<:StaticArray,T<:Number}(op::Op, ::Type{A}, ::Type{T}) = similar_type(A, promote_op(op, eltype(A), T))
+Base.promote_op{Op,T<:Number,A<:StaticArray}(op::Op, ::Type{T}, ::Type{A}) = similar_type(A, promote_op(op, T, eltype(A)))
+
+
 # TODO lots more operators
 
 @inline .-(a1::StaticArray) = broadcast(-, a1)

--- a/test/arraymath.jl
+++ b/test/arraymath.jl
@@ -1,4 +1,15 @@
 @testset "Array math" begin
+    @testset "AbstractArray-of-StaticArray with scalar math" begin
+        v = SVector{2,Float64}[SVector{2,Float64}(1,1)]
+        @test v .* 1.0 == v
+        @test typeof(v .* 1.0) == typeof(v)
+        @test 1 .- v == v .- v
+        @test typeof(1 .- v) == typeof(v)
+        v2 = SVector{2,Int}[SVector{2,Int}(1,1)]
+        @test v2 .* 1.0 == v
+        @test typeof(v2 .* 1.0) == typeof(v)
+    end
+
     @testset "Array-scalar math" begin
         m = @SMatrix [1 2; 3 4]
 


### PR DESCRIPTION
For some reason, there's special rules using Base.promote_op to infer
the correct type for operations involving Number and arrays of other
types.  This means we need to overload promote_op or we'll get an Array
of Any in these cases.

See https://github.com/SimonDanisch/FixedSizeArrays.jl/issues/156 for a similar issue.